### PR TITLE
Fix Compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Or install it yourself as:
   </tr>
   <tr>
     <th>Producer API</th>
-    <td>Full support</td>
+    <td>Full support in v0.4.x</td>
     <td>Full support in v0.4.x</td>
     <td>Full support in v0.5.x</td>
     <td>Limited support</td>


### PR DESCRIPTION
0.5.x is not able to write to a Kafka 0.8 cluster.